### PR TITLE
Fixed footer links, redirect not working

### DIFF
--- a/lib/Footer.js
+++ b/lib/Footer.js
@@ -40,8 +40,8 @@ export function Footer() {
             color="dimmed"
             key='GitHub'
             href='https://github.com/bryanmontalvan/shareddaily'
-            onClick={(event) => event.preventDefault()}
             size="sm"
+            target="_blank"
           >
             GitHub
           </Anchor>
@@ -49,8 +49,8 @@ export function Footer() {
             color="dimmed"
             key='Mantine'
             href='https://mantine.dev/'
-            onClick={(event) => event.preventDefault()}
             size="sm"
+            target="_blank"
           >
             Created using <b>Mantine</b>
           </Anchor>


### PR DESCRIPTION
## Description
This commit fixes the footer links from redirecting users to provided links.
- Removed onClick preventDefault hook
- Added target(_blank) to open a new tab

## Issue

resolves #9 